### PR TITLE
Allow use of DBT_PROJECT_DIR env var as per help text and dbt cli

### DIFF
--- a/opendbt/__main__.py
+++ b/opendbt/__main__.py
@@ -1,7 +1,23 @@
 import argparse
+import os
 from pathlib import Path
 
 from opendbt import OpenDbtCli, default_project_dir, default_profiles_dir
+
+
+class EnvDefault(argparse.Action):
+    def __init__(
+        self, option_strings, dest, envvar, required=True, default=None, **kwargs
+    ):
+        default = os.environ.get(envvar, default)
+        if required and default:
+            required = False
+        super().__init__(
+            option_strings, dest, default=default, required=required, **kwargs
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
 
 
 def main():
@@ -9,11 +25,15 @@ def main():
     parser.add_argument(
         "--project-dir",
         default=None,
+        action=EnvDefault,
+        envvar="DBT_PROJECT_DIR",
         help="Path to the dbt project directory. Defaults to the DBT_PROJECT_DIR environment variable or the current working directory.",
     )
     parser.add_argument(
         "--profiles-dir",
         default=None,
+        action=EnvDefault,
+        envvar="DBT_PROFILES_DIR",
         help="Path to the dbt profiles directory. Defaults to the DBT_PROFILES_DIR environment variable.",
     )
     ns, args = parser.parse_known_args()


### PR DESCRIPTION
Fix to make `DBT_PROJECT_DIR` and `DBT_PROFILES_DIR` env vars work as cli defaults.

dbt cli allows this, and the help text in opendbt cli args say you can but it doesn't work.

The reason is it currently just takes the argparse result (`None`) and falls back to `else default_project_dir()` ...but the dbt `default_project_dir` function doesn't do the env var handling.

Instead that is a feature of the `click` interface:
https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/cli/params.py#L476

So for dbt cli the default function is only called if no env var defined.

We can reproduce the same behaviour in argparse with some helper code adapted from:
https://stackoverflow.com/a/10551190/202168