### PR TITLE
Fix for `docs generate --static` error

### DIFF
--- a/opendbt/dbt/__init__.py
+++ b/opendbt/dbt/__init__.py
@@ -12,14 +12,14 @@ try:
     dbt_version = Version(version.get_installed_version().to_version_string(skip_matcher=True))
     if Version("1.7.0") <= dbt_version < Version("1.8.0"):
         RuntimePatcher(module_name="dbt.include.global_project").patch_attribute(attribute_name="DOCS_INDEX_FILE_PATH",
-                                                                                 new_value=str(OPENDBT_INDEX_HTML_FILE))
+                                                                                 new_value=OPENDBT_INDEX_HTML_FILE.as_posix())
         from opendbt.dbt.v17.adapters.factory import OpenDbtAdapterContainer
         from opendbt.dbt.v17.task.docs.generate import OpenDbtGenerateTask
         from opendbt.dbt.v17.config.runtime import OpenDbtRuntimeConfig
         from opendbt.dbt.v17.task.run import OpenDbtModelRunner
     elif Version("1.8.0") <= dbt_version < Version("1.11.0"):
         RuntimePatcher(module_name="dbt.task.docs").patch_attribute(attribute_name="DOCS_INDEX_FILE_PATH",
-                                                                    new_value=str(OPENDBT_INDEX_HTML_FILE))
+                                                                    new_value=OPENDBT_INDEX_HTML_FILE.as_posix())
         from opendbt.dbt.v18.adapters.factory import OpenDbtAdapterContainer
         from opendbt.dbt.v18.task.docs.generate import OpenDbtGenerateTask
         from opendbt.dbt.v18.config.runtime import OpenDbtRuntimeConfig

--- a/opendbt/dbt/__init__.py
+++ b/opendbt/dbt/__init__.py
@@ -12,14 +12,14 @@ try:
     dbt_version = Version(version.get_installed_version().to_version_string(skip_matcher=True))
     if Version("1.7.0") <= dbt_version < Version("1.8.0"):
         RuntimePatcher(module_name="dbt.include.global_project").patch_attribute(attribute_name="DOCS_INDEX_FILE_PATH",
-                                                                                 new_value=OPENDBT_INDEX_HTML_FILE)
+                                                                                 new_value=str(OPENDBT_INDEX_HTML_FILE))
         from opendbt.dbt.v17.adapters.factory import OpenDbtAdapterContainer
         from opendbt.dbt.v17.task.docs.generate import OpenDbtGenerateTask
         from opendbt.dbt.v17.config.runtime import OpenDbtRuntimeConfig
         from opendbt.dbt.v17.task.run import OpenDbtModelRunner
     elif Version("1.8.0") <= dbt_version < Version("1.11.0"):
         RuntimePatcher(module_name="dbt.task.docs").patch_attribute(attribute_name="DOCS_INDEX_FILE_PATH",
-                                                                    new_value=OPENDBT_INDEX_HTML_FILE)
+                                                                    new_value=str(OPENDBT_INDEX_HTML_FILE))
         from opendbt.dbt.v18.adapters.factory import OpenDbtAdapterContainer
         from opendbt.dbt.v18.task.docs.generate import OpenDbtGenerateTask
         from opendbt.dbt.v18.config.runtime import OpenDbtRuntimeConfig


### PR DESCRIPTION
When I run `dbt docs generate --static` I get this error:

```
  File ".venv/lib/python3.11/site-packages/opendbt/dbt/v18/task/docs/generate.py", line 33, in run
    result = super().run()
             ^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/dbt/task/docs/generate.py", line 329, in run
    index_data = load_file_contents(DOCS_INDEX_FILE_PATH)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/dbt_common/record.py", line 507, in record_replay_wrapper
    return func_to_record(*call_args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/dbt_common/clients/system.py", line 176, in load_file_contents
    path = convert_path(path)
           ^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/dbt_common/clients/system.py", line 408, in convert_path
    if len(path) < 250:
       ^^^^^^^^^
TypeError: object of type 'PosixPath' has no len()
```

Adding this cast to string when patching fixes it for me.