### PR TITLE
Avoid spurious "Compiled code not found" warnings

### DIFF
--- a/opendbt/catalog/__init__.py
+++ b/opendbt/catalog/__init__.py
@@ -205,7 +205,7 @@ class OpenDbtNode(OpenDbtLogger):
         return self.columns
 
     def sqlglot_column_lineage_map(self):
-        if not self.compiled_code:
+        if self.resource_type == "model" and not self.compiled_code:
             self.log.warning(f"Compiled code not found for model {self.unique_id}")
             return {}
 


### PR DESCRIPTION
Currently getting these warnings for seeds and sources when doing `dbt docs generate`:

> [2025-06-30 18:06:22,104] {__init__.py:215} WARNING - Compiled code not found for model seed.analyticsng.seed_franchise_brands
WARNING:opendbt:Compiled code not found for model seed.analyticsng.seed_franchise_brands
[2025-06-30 18:06:22,104] {__init__.py:215} WARNING - Compiled code not found for model source.analyticsng.raw_data.companyworkflows
WARNING:opendbt:Compiled code not found for model source.analyticsng.raw_data.companyworkflows

but it's my understanding that they would never have compiled sql, so we could just skip the warning in those cases