### PR TITLE
Add dbt 1.11 support

### DIFF
--- a/.github/workflows/tests-dbt-version.yml
+++ b/.github/workflows/tests-dbt-version.yml
@@ -9,6 +9,10 @@ on:
       dbt-duckdb-version:
         required: true
         type: string
+      python-versions:
+        required: false
+        type: string
+        default: '["3.9", "3.10", "3.11", "3.12"]'
 
 jobs:
   test-dbt-version:
@@ -16,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: ${{ fromJson(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,18 @@ on:
       - '.run/**'
 
 jobs:
+  test-dbt-1-11:
+    uses: ./.github/workflows/tests-dbt-version.yml
+    with:
+      dbt-version: "1.11"
+      dbt-duckdb-version: "1.10"
+      python-versions: '["3.10", "3.11", "3.12"]'
   test-dbt-1-10:
     uses: ./.github/workflows/tests-dbt-version.yml
     with:
       dbt-version: "1.10"
       dbt-duckdb-version: "1.9"
+    needs: test-dbt-1-11
   test-dbt-1-9:
     uses: ./.github/workflows/tests-dbt-version.yml
     with:

--- a/opendbt/dbt/__init__.py
+++ b/opendbt/dbt/__init__.py
@@ -17,7 +17,7 @@ try:
         from opendbt.dbt.v17.task.docs.generate import OpenDbtGenerateTask
         from opendbt.dbt.v17.config.runtime import OpenDbtRuntimeConfig
         from opendbt.dbt.v17.task.run import OpenDbtModelRunner
-    elif Version("1.8.0") <= dbt_version < Version("1.11.0"):
+    elif Version("1.8.0") <= dbt_version < Version("1.12.0"):
         RuntimePatcher(module_name="dbt.task.docs").patch_attribute(attribute_name="DOCS_INDEX_FILE_PATH",
                                                                     new_value=OPENDBT_INDEX_HTML_FILE.as_posix())
         from opendbt.dbt.v18.adapters.factory import OpenDbtAdapterContainer

--- a/tests/resources/dbtcore/models/my_executedlt_model.py
+++ b/tests/resources/dbtcore/models/my_executedlt_model.py
@@ -1,7 +1,9 @@
 import dlt
 
 @dlt.resource(
-    columns={"event_tstamp": {"data_type": "timestamp", "precision": 3}},
+    columns={
+        "event_tstamp": {"data_type": "timestamp", "precision": 3},
+    },
     primary_key="event_id",
 )
 def events():


### PR DESCRIPTION
 Added support dbt-core 1.11.x                                                                         
                                                                                                  
  - Bump version check upper bound from 1.11.0 to 1.12.0                                          
  - Fix test model my_executedlt_model.py: dbt 1.11 rejects adjacent closing                      
    braces `}}` in Python models as false-positive jinja detection, reformatted                   
    nested dict to avoid this                                                                     
  - Add dbt 1.11 to CI test matrix (dbt-core 1.11, dbt-duckdb 1.10)                               
  - Parameterize python-versions in test workflow since dbt 1.11 requires                         
    Python >= 3.10