### PR TITLE
Resolve opendbt_docs_projects Variable dynamically + sqlglot v30 fix

### DIFF
--- a/opendbt/airflow/plugin.py
+++ b/opendbt/airflow/plugin.py
@@ -87,8 +87,8 @@ class DBTDocsView(BaseView):
     default_view = "dbt_docs_index"
 
     def __init__(self, project_paths=None):
-        super().__init__()
         self._static_project_paths = project_paths
+        super().__init__()
 
     @property
     def projects(self) -> Dict[str, Path]:

--- a/opendbt/airflow/plugin.py
+++ b/opendbt/airflow/plugin.py
@@ -86,9 +86,14 @@ class DBTDocsView(BaseView):
     route_base = "/dbt"
     default_view = "dbt_docs_index"
 
-    def __init__(self, projects: Dict[str, Path]):
+    def __init__(self, project_paths=None):
         super().__init__()
-        self.projects = projects
+        self._static_project_paths = project_paths
+
+    @property
+    def projects(self) -> Dict[str, Path]:
+        """Resolve projects dynamically so Variable changes take effect without restart."""
+        return get_projects(self._static_project_paths)
 
     def _check_configuration(self) -> Optional[Response]:
         """Check if configuration is valid. Returns error response if invalid, None if OK."""
@@ -216,8 +221,7 @@ def init_plugins_dbtdocs_page(
     Returns:
         AirflowPlugin class
     """
-    projects = get_projects(dbt_docs_dir)
-    view = DBTDocsView(projects)
+    view = DBTDocsView(project_paths=dbt_docs_dir)
 
     static_folder = None
     

--- a/opendbt/catalog/__init__.py
+++ b/opendbt/catalog/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 import sqlglot
 import tqdm
-from sqlglot import Expression
+from sqlglot.expressions import Expression
 from sqlglot.lineage import lineage, SqlglotError, exp
 
 from opendbt.logger import OpenDbtLogger


### PR DESCRIPTION
## Summary

- **Dynamic Variable resolution**: `DBTDocsView.projects` is now a `@property` that calls `get_projects()` per request, so changes to the Airflow Variable `opendbt_docs_projects` take effect immediately without restarting the webserver.
- **sqlglot v30 compatibility**: `from sqlglot import Expression` -> `from sqlglot.expressions import Expression` (sqlglot v30 moved it to the submodule).
- **Init order fix**: `_static_project_paths` is set before `super().__init__()` because `BaseView.__init__` triggers property access.

## Test plan

- [ ] Verify dbt docs page loads after deployment
- [x] Change `opendbt_docs_projects` Variable in Airflow UI -> verify new project appears without restart
- [ ] Verify `opendbt` imports cleanly with sqlglot >= 30